### PR TITLE
Improve user response formatting for country data

### DIFF
--- a/sql/005_countries.sql
+++ b/sql/005_countries.sql
@@ -1,0 +1,18 @@
+create extension if not exists pgcrypto;
+
+create table if not exists countries (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  iso_code text unique,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+  constraint iso_code_length check (iso_code is null or char_length(iso_code) = 2)
+);
+
+alter table if exists users
+  add column if not exists phone_number text;
+
+alter table if exists users
+  add column if not exists country_id uuid references countries(id);
+
+create index if not exists idx_users_country_id on users(country_id);

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,22 +1,105 @@
 const pool = require("../config/db");
 const { hashPassword, comparePassword } = require("../utils/password");
 const { signToken } = require("../utils/tokens");
-exports.register=async(req,res)=>{
- try{
-  const {name,email,password,role}=req.body;
-  if(!name||!email||!password||!role) return res.status(400).json({error:"name, email, password, role are required"});
-  const hashed=await hashPassword(password);
-  const q=await pool.query(`INSERT INTO users (name,email,password_hash,role) VALUES ($1,$2,$3,$4) RETURNING id,name,email,role,status,created_at`,[name,email,hashed,role]);
-  const user=q.rows[0]; const token=signToken({id:user.id,role:user.role,email:user.email}); res.status(201).json({user,token});
- }catch(e){ if(e.code==="23505") return res.status(409).json({error:"Email already registered"}); res.status(500).json({error:"Registration failed"}); }
+const { resolveName } = require("../utils/names");
+const { formatUserRow } = require("../utils/users");
+
+exports.register = async (req, res) => {
+  try {
+    const {
+      name,
+      firstName,
+      lastName,
+      email,
+      password,
+      role,
+      countryId,
+      phone,
+      phoneNumber,
+    } = req.body;
+    const safeName = resolveName(name, firstName, lastName);
+    const safePhone = (() => {
+      const source =
+        typeof phoneNumber === "string" && phoneNumber.trim()
+          ? phoneNumber
+          : phone;
+      return typeof source === "string" && source.trim()
+        ? source.trim()
+        : null;
+    })();
+    let safeCountryId = null;
+    if (typeof countryId === "string" && countryId.trim()) {
+      const trimmedCountryId = countryId.trim();
+      const uuidPattern =
+        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+      if (!uuidPattern.test(trimmedCountryId)) {
+        return res
+          .status(400)
+          .json({ error: "countryId must be a valid UUID" });
+      }
+      safeCountryId = trimmedCountryId;
+    }
+
+    if (!safeName || !email || !password || !role) {
+      return res
+        .status(400)
+        .json({
+          error: "A name (or firstName/lastName), email, password, and role are required",
+        });
+    }
+
+    if (safeCountryId) {
+      const countryCheck = await pool.query(
+        `SELECT id FROM countries WHERE id=$1`,
+        [safeCountryId]
+      );
+      if (!countryCheck.rows[0]) {
+        return res.status(400).json({ error: "countryId not found" });
+      }
+    }
+
+    const hashed = await hashPassword(password);
+    const q = await pool.query(
+      `INSERT INTO users (name,email,password_hash,role,phone_number,country_id)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       RETURNING id,name,email,role,status,created_at,updated_at,phone_number,country_id`,
+      [safeName, email, hashed, role, safePhone, safeCountryId]
+    );
+
+    const user = formatUserRow(q.rows[0]);
+    const token = signToken({ id: user.id, role: user.role, email: user.email });
+
+    res.status(201).json({ user, token });
+  } catch (e) {
+    if (e.code === "23505") {
+      return res.status(409).json({ error: "Email already registered" });
+    }
+    res.status(500).json({ error: "Registration failed" });
+  }
 };
-exports.login=async(req,res)=>{
- try{
-  const {email,password}=req.body; if(!email||!password) return res.status(400).json({error:"email and password required"});
-  const q=await pool.query("SELECT * FROM users WHERE email=$1",[email]); const user=q.rows[0];
-  if(!user) return res.status(401).json({error:"Invalid credentials"});
-  const ok=await comparePassword(password,user.password_hash); if(!ok) return res.status(401).json({error:"Invalid credentials"});
-  const token=signToken({id:user.id,role:user.role,email:user.email}); res.json({token});
- }catch(e){ res.status(500).json({error:"Login failed"}); }
+
+exports.login = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ error: "email and password required" });
+    }
+    const q = await pool.query("SELECT * FROM users WHERE email=$1", [email]);
+    const user = q.rows[0];
+    if (!user) {
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+    const ok = await comparePassword(password, user.password_hash);
+    if (!ok) {
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+    const token = signToken({ id: user.id, role: user.role, email: user.email });
+    res.json({ token });
+  } catch (e) {
+    res.status(500).json({ error: "Login failed" });
+  }
 };
-exports.logout=async(_req,res)=>{ res.json({message:"Logged out (client should discard token)"}); };
+
+exports.logout = async (_req, res) => {
+  res.json({ message: "Logged out (client should discard token)" });
+};

--- a/src/controllers/country.controller.js
+++ b/src/controllers/country.controller.js
@@ -1,0 +1,52 @@
+const pool = require("../config/db");
+
+const mapCountry = (row) => ({
+  id: row.id,
+  name: row.name,
+  isoCode: row.iso_code,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+exports.list = async (_req, res) => {
+  try {
+    const q = await pool.query(
+      `SELECT id, name, iso_code, created_at, updated_at FROM countries ORDER BY name ASC`
+    );
+    res.json({ countries: q.rows.map(mapCountry) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to list countries" });
+  }
+};
+
+exports.create = async (req, res) => {
+  try {
+    const { name, isoCode } = req.body;
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+    const normalizedIso =
+      typeof isoCode === "string" && isoCode.trim()
+        ? isoCode.trim().toUpperCase()
+        : null;
+
+    if (!trimmedName) {
+      return res.status(400).json({ error: "name is required" });
+    }
+
+    if (normalizedIso && normalizedIso.length !== 2) {
+      return res.status(400).json({ error: "isoCode must be 2 characters" });
+    }
+
+    const q = await pool.query(
+      `INSERT INTO countries (name, iso_code) VALUES ($1, $2)
+       RETURNING id, name, iso_code, created_at, updated_at`,
+      [trimmedName, normalizedIso]
+    );
+
+    res.status(201).json({ country: mapCountry(q.rows[0]) });
+  } catch (e) {
+    if (e.code === "23505") {
+      return res.status(409).json({ error: "Country already exists" });
+    }
+    res.status(500).json({ error: "Failed to create country" });
+  }
+};

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,4 +1,49 @@
 const pool = require("../config/db");
-exports.me=async(req,res)=>{ try{ const q=await pool.query(`SELECT id,name,email,role,status,created_at,updated_at FROM users WHERE id=$1`,[req.user.id]); res.json({user:q.rows[0]}); }catch(e){ res.status(500).json({error:"Failed to fetch profile"});} };
-exports.list=async(_req,res)=>{ try{ const q=await pool.query(`SELECT id,name,email,role,status,created_at FROM users ORDER BY created_at DESC`); res.json({users:q.rows}); }catch(e){ res.status(500).json({error:"Failed to list users"});} };
-exports.getById=async(req,res)=>{ try{ const q=await pool.query(`SELECT id,name,email,role,status,created_at FROM users WHERE id=$1`,[req.params.id]); if(!q.rows[0]) return res.status(404).json({error:"Not found"}); res.json({user:q.rows[0]}); }catch(e){ res.status(500).json({error:"Failed to get user"});} };
+const { formatUserRow } = require("../utils/users");
+
+const baseUserQuery = `
+  SELECT
+    u.id,
+    u.name,
+    u.email,
+    u.role,
+    u.status,
+    u.created_at,
+    u.updated_at,
+    u.phone_number,
+    u.country_id,
+    c.name AS country_name,
+    c.iso_code AS country_iso_code
+  FROM users u
+  LEFT JOIN countries c ON c.id = u.country_id
+`;
+
+exports.me = async (req, res) => {
+  try {
+    const q = await pool.query(`${baseUserQuery} WHERE u.id = $1`, [req.user.id]);
+    res.json({ user: formatUserRow(q.rows[0]) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to fetch profile" });
+  }
+};
+
+exports.list = async (_req, res) => {
+  try {
+    const q = await pool.query(`${baseUserQuery} ORDER BY u.created_at DESC`);
+    res.json({ users: q.rows.map(formatUserRow) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to list users" });
+  }
+};
+
+exports.getById = async (req, res) => {
+  try {
+    const q = await pool.query(`${baseUserQuery} WHERE u.id = $1`, [req.params.id]);
+    if (!q.rows[0]) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    res.json({ user: formatUserRow(q.rows[0]) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to get user" });
+  }
+};

--- a/src/routes/country.routes.js
+++ b/src/routes/country.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const countries = require("../controllers/country.controller");
+const { requireAuth, requireRole } = require("../middleware/auth");
+
+router.get("/", countries.list);
+router.post("/", requireAuth, requireRole("admin"), countries.create);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -23,6 +23,7 @@ app.use("/users", require("./routes/user.routes"));
 app.use("/services", require("./routes/service.routes"));
 app.use("/items", require("./routes/item.routes"));
 app.use("/bookings", require("./routes/booking.routes"));
+app.use("/countries", require("./routes/country.routes"));
 
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/utils/names.js
+++ b/src/utils/names.js
@@ -1,0 +1,33 @@
+const normalize = (value) =>
+  typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+
+const resolveName = (name, firstName, lastName) => {
+  const legacy = normalize(name);
+  if (legacy) {
+    return legacy;
+  }
+
+  const safeFirst = normalize(firstName);
+  const safeLast = normalize(lastName);
+
+  const combined = [safeFirst, safeLast].filter(Boolean).join(" ");
+  return combined.trim();
+};
+
+const splitName = (fullName) => {
+  const normalized = normalize(fullName);
+  if (!normalized) {
+    return { firstName: "", lastName: "" };
+  }
+
+  const [first, ...rest] = normalized.split(" ");
+  return {
+    firstName: first || "",
+    lastName: rest.join(" ") || "",
+  };
+};
+
+module.exports = {
+  resolveName,
+  splitName,
+};

--- a/src/utils/users.js
+++ b/src/utils/users.js
@@ -1,0 +1,53 @@
+const { splitName } = require("./names");
+
+const has = (row, key) => Object.prototype.hasOwnProperty.call(row, key);
+
+const buildCountry = (row) => {
+  if (!has(row, "country_id") && !has(row, "country_name") && !has(row, "country_iso_code")) {
+    return undefined;
+  }
+
+  const present = row.country_id || row.country_name || row.country_iso_code;
+  if (!present) {
+    return null;
+  }
+
+  return {
+    id: row.country_id || null,
+    name: row.country_name || null,
+    isoCode: row.country_iso_code || null,
+  };
+};
+
+const formatUserRow = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  const { firstName, lastName } = splitName(row.name);
+
+  const formatted = {
+    id: row.id,
+    name: row.name,
+    firstName,
+    lastName,
+    email: row.email,
+    role: row.role,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    phoneNumber: has(row, "phone_number") ? row.phone_number : undefined,
+    countryId: has(row, "country_id") ? row.country_id : undefined,
+  };
+
+  const country = buildCountry(row);
+  if (country !== undefined) {
+    formatted.country = country;
+  }
+
+  return formatted;
+};
+
+module.exports = {
+  formatUserRow,
+};


### PR DESCRIPTION
## Summary
- add a shared formatter to present database user rows with derived name parts and camelCase metadata
- update registration and user endpoints to reuse the formatter
- expose country controller responses with camelCase properties

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54761c1488324a8d5d3bbc0c63311