### PR TITLE
Add SQL seed scripts for states and cities

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "nodemon src/server.js"
+    "dev": "nodemon src/server.js",
+    "seed:cities": "node scripts/seedCities.js",
+    "seed:countries": "node scripts/seedCountries.js",
+    "seed:states": "node scripts/seedStates.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/scripts/seedCities.js
+++ b/scripts/seedCities.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+require("dotenv").config();
+
+const path = require("path");
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is required to seed cities");
+  process.exit(1);
+}
+
+const pool = require("../src/config/db");
+const { parseCsv } = require("./utils/csv");
+const { createCountryFinder, createStateFinder } = require("./utils/locations");
+
+const CSV_FILE = path.join(__dirname, "../sql/data/cities.csv");
+
+(async () => {
+  const rows = parseCsv(CSV_FILE);
+
+  if (!rows.length) {
+    console.log("No cities found in CSV. Nothing to seed.");
+    process.exit(0);
+  }
+
+  const client = await pool.connect();
+  const findCountryId = createCountryFinder(client);
+  const findStateId = createStateFinder(client);
+
+  try {
+    await client.query("BEGIN");
+    const tableCheck = await client.query(
+      "SELECT to_regclass('public.cities') AS identifier"
+    );
+
+    if (!tableCheck.rows[0] || !tableCheck.rows[0].identifier) {
+      throw new Error("cities table does not exist. Run migrations first.");
+    }
+
+    let processed = 0;
+    for (const row of rows) {
+      const cityName = row.city_name || row.name;
+      const isoCode = row.country_iso_code || row.iso_code;
+      const countryName = row.country_name || "";
+      const stateCode = row.state_code || "";
+      const stateName = row.state_name || "";
+
+      if (!cityName || !cityName.trim()) {
+        continue;
+      }
+
+      const countryId = await findCountryId(isoCode, countryName);
+      let stateId = null;
+
+      const hasStateInfo =
+        (stateCode && stateCode.trim().length > 0) ||
+        (stateName && stateName.trim().length > 0);
+
+      if (hasStateInfo) {
+        try {
+          stateId = await findStateId(countryId, stateCode, stateName);
+        } catch (stateError) {
+          throw new Error(
+            `Failed to resolve state for city "${cityName}": ${stateError.message}`
+          );
+        }
+      }
+
+      await client.query(
+        `INSERT INTO cities (name, country_id, state_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (country_id, state_lookup, name)
+         DO UPDATE SET state_id = EXCLUDED.state_id, updated_at = NOW()`,
+        [cityName.trim(), countryId, stateId]
+      );
+      processed += 1;
+    }
+
+    await client.query("COMMIT");
+    console.log(`Seeded ${processed} cities.`);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    console.error("Failed to seed cities", error);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+})();

--- a/scripts/seedCountries.js
+++ b/scripts/seedCountries.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+require("dotenv").config();
+
+const path = require("path");
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is required to seed countries");
+  process.exit(1);
+}
+
+const pool = require("../src/config/db");
+const { parseCsv } = require("./utils/csv");
+
+const CSV_FILE = path.join(__dirname, "../sql/data/countries.csv");
+
+(async () => {
+  const rows = parseCsv(CSV_FILE);
+
+  if (!rows.length) {
+    console.log("No countries found in CSV. Nothing to seed.");
+    process.exit(0);
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const tableCheck = await client.query(
+      "SELECT to_regclass('public.countries') AS identifier"
+    );
+
+    if (!tableCheck.rows[0] || !tableCheck.rows[0].identifier) {
+      throw new Error("countries table does not exist. Run migrations first.");
+    }
+
+    let processed = 0;
+    for (const row of rows) {
+      const name = row.name ? row.name.trim() : "";
+      const iso = row.iso_code ? row.iso_code.trim().toUpperCase() : null;
+
+      if (!name) {
+        continue;
+      }
+
+      if (iso && iso.length !== 2) {
+        throw new Error(`Invalid ISO code for country "${name}": ${iso}`);
+      }
+
+      try {
+        await client.query(
+          `INSERT INTO countries (name, iso_code)
+           VALUES ($1, $2)
+           ON CONFLICT (name)
+           DO UPDATE SET iso_code = EXCLUDED.iso_code, updated_at = NOW()`,
+          [name, iso || null]
+        );
+      } catch (error) {
+        if (error.code === "23505" && error.constraint === "countries_iso_code_key" && iso) {
+          await client.query(
+            `UPDATE countries
+             SET name = $1, updated_at = NOW()
+             WHERE iso_code = $2`,
+            [name, iso]
+          );
+        } else {
+          throw error;
+        }
+      }
+      processed += 1;
+    }
+    await client.query("COMMIT");
+    console.log(`Seeded ${processed} countries.`);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    console.error("Failed to seed countries", error);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+})();

--- a/scripts/seedStates.js
+++ b/scripts/seedStates.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+require("dotenv").config();
+
+const path = require("path");
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is required to seed states");
+  process.exit(1);
+}
+
+const pool = require("../src/config/db");
+const { parseCsv } = require("./utils/csv");
+const { createCountryFinder } = require("./utils/locations");
+
+const CSV_FILE = path.join(__dirname, "../sql/data/states.csv");
+
+(async () => {
+  const rows = parseCsv(CSV_FILE);
+
+  if (!rows.length) {
+    console.log("No states found in CSV. Nothing to seed.");
+    process.exit(0);
+  }
+
+  const client = await pool.connect();
+  const findCountryId = createCountryFinder(client);
+  try {
+    await client.query("BEGIN");
+    const tableCheck = await client.query(
+      "SELECT to_regclass('public.states') AS identifier"
+    );
+
+    if (!tableCheck.rows[0] || !tableCheck.rows[0].identifier) {
+      throw new Error("states table does not exist. Run migrations first.");
+    }
+
+    let processed = 0;
+    for (const row of rows) {
+      const stateName = row.state_name || row.name;
+      const stateCode = row.state_code ? row.state_code.trim() : "";
+      const isoCode = row.country_iso_code || row.iso_code;
+      const countryName = row.country_name || "";
+
+      if (!stateName || !stateName.trim()) {
+        continue;
+      }
+
+      if (stateCode && stateCode.length > 10) {
+        throw new Error(
+          `State code for "${stateName}" is too long (max 10 characters)`
+        );
+      }
+
+      const countryId = await findCountryId(isoCode, countryName);
+
+      await client.query(
+        `INSERT INTO states (name, code, country_id)
+         VALUES ($1, NULLIF($2, ''), $3)
+         ON CONFLICT (country_id, name)
+         DO UPDATE SET code = EXCLUDED.code, updated_at = NOW()`,
+        [stateName.trim(), stateCode, countryId]
+      );
+      processed += 1;
+    }
+
+    await client.query("COMMIT");
+    console.log(`Seeded ${processed} states.`);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    console.error("Failed to seed states", error);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+})();

--- a/scripts/utils/csv.js
+++ b/scripts/utils/csv.js
@@ -1,0 +1,57 @@
+const fs = require("fs");
+
+const stripBom = (content) => (content.charCodeAt(0) === 0xfeff ? content.slice(1) : content);
+
+const splitCsvLine = (line) => {
+  const values = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === "\"") {
+      const next = line[i + 1];
+      if (inQuotes && next === "\"") {
+        current += "\"";
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      values.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  values.push(current);
+  return values.map((value) => value.trim());
+};
+
+const parseCsv = (filePath) => {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const content = stripBom(raw);
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length <= 1) {
+    return [];
+  }
+
+  const headers = splitCsvLine(lines[0]).map((header) => header.toLowerCase());
+  return lines.slice(1).map((line) => {
+    const values = splitCsvLine(line);
+    return headers.reduce((acc, header, index) => {
+      acc[header] = values[index] ? values[index].trim() : "";
+      return acc;
+    }, {});
+  });
+};
+
+module.exports = {
+  parseCsv,
+};

--- a/scripts/utils/locations.js
+++ b/scripts/utils/locations.js
@@ -1,0 +1,123 @@
+const getCacheKey = (prefix, value) => `${prefix}:${value}`;
+
+const createCountryFinder = (client) => {
+  const cache = new Map();
+
+  return async (isoCode, countryName) => {
+    const normalizedIso = isoCode ? isoCode.trim().toUpperCase() : null;
+    const normalizedName = countryName ? countryName.trim().toLowerCase() : null;
+
+    if (!normalizedIso && !normalizedName) {
+      throw new Error("Missing country identifier");
+    }
+
+    if (normalizedIso) {
+      const cacheKey = getCacheKey("iso", normalizedIso);
+      if (cache.has(cacheKey)) {
+        return cache.get(cacheKey);
+      }
+      const q = await client.query(
+        "SELECT id, name FROM countries WHERE iso_code = $1",
+        [normalizedIso]
+      );
+      if (q.rows[0]) {
+        cache.set(cacheKey, q.rows[0].id);
+        if (normalizedName) {
+          cache.set(getCacheKey("name", normalizedName), q.rows[0].id);
+        }
+        return q.rows[0].id;
+      }
+    }
+
+    if (normalizedName) {
+      const cacheKey = getCacheKey("name", normalizedName);
+      if (cache.has(cacheKey)) {
+        return cache.get(cacheKey);
+      }
+      const q = await client.query(
+        "SELECT id, iso_code FROM countries WHERE LOWER(name) = $1",
+        [normalizedName]
+      );
+      if (q.rows[0]) {
+        cache.set(cacheKey, q.rows[0].id);
+        if (q.rows[0].iso_code) {
+          cache.set(getCacheKey("iso", q.rows[0].iso_code), q.rows[0].id);
+        }
+        return q.rows[0].id;
+      }
+    }
+
+    throw new Error(
+      `Country not found. iso_code="${normalizedIso || ""}" name="${
+        countryName || ""
+      }"`
+    );
+  };
+};
+
+const createStateFinder = (client) => {
+  const cache = new Map();
+
+  return async (countryId, stateCode, stateName) => {
+    const normalizedCode = stateCode ? stateCode.trim().toUpperCase() : null;
+    const normalizedName = stateName ? stateName.trim().toLowerCase() : null;
+
+    if (!countryId) {
+      throw new Error("countryId is required to resolve a state");
+    }
+
+    if (!normalizedCode && !normalizedName) {
+      return null;
+    }
+
+    if (normalizedCode) {
+      const cacheKey = getCacheKey("code", `${countryId}:${normalizedCode}`);
+      if (cache.has(cacheKey)) {
+        return cache.get(cacheKey);
+      }
+      const q = await client.query(
+        "SELECT id FROM states WHERE country_id = $1 AND UPPER(code) = $2",
+        [countryId, normalizedCode]
+      );
+      if (q.rows[0]) {
+        cache.set(cacheKey, q.rows[0].id);
+        if (normalizedName) {
+          cache.set(getCacheKey("name", `${countryId}:${normalizedName}`), q.rows[0].id);
+        }
+        return q.rows[0].id;
+      }
+    }
+
+    if (normalizedName) {
+      const cacheKey = getCacheKey("name", `${countryId}:${normalizedName}`);
+      if (cache.has(cacheKey)) {
+        return cache.get(cacheKey);
+      }
+      const q = await client.query(
+        "SELECT id, code FROM states WHERE country_id = $1 AND LOWER(name) = $2",
+        [countryId, normalizedName]
+      );
+      if (q.rows[0]) {
+        cache.set(cacheKey, q.rows[0].id);
+        if (q.rows[0].code) {
+          cache.set(
+            getCacheKey("code", `${countryId}:${q.rows[0].code.toUpperCase()}`),
+            q.rows[0].id
+          );
+        }
+        return q.rows[0].id;
+      }
+    }
+
+    throw new Error(
+      `State not found for country ${countryId}. code="${normalizedCode || ""}" name="${
+        stateName || ""
+      }"`
+    );
+  };
+};
+
+module.exports = {
+  createCountryFinder,
+  createStateFinder,
+};

--- a/sql/005_countries.sql
+++ b/sql/005_countries.sql
@@ -1,0 +1,18 @@
+create extension if not exists pgcrypto;
+
+create table if not exists countries (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  iso_code text unique,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+  constraint iso_code_length check (iso_code is null or char_length(iso_code) = 2)
+);
+
+alter table if exists users
+  add column if not exists phone_number text;
+
+alter table if exists users
+  add column if not exists country_id uuid references countries(id);
+
+create index if not exists idx_users_country_id on users(country_id);

--- a/sql/006_states.sql
+++ b/sql/006_states.sql
@@ -1,0 +1,15 @@
+create extension if not exists pgcrypto;
+
+create table if not exists states (
+  id uuid primary key default gen_random_uuid(),
+  country_id uuid not null references countries(id) on delete cascade,
+  name text not null,
+  code text,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+  constraint states_country_id_name_key unique (country_id, name),
+  constraint states_code_length check (code is null or char_length(code) <= 10)
+);
+
+create index if not exists idx_states_country_id on states(country_id);
+create unique index if not exists idx_states_country_id_code on states(country_id, code) where code is not null;

--- a/sql/007_cities.sql
+++ b/sql/007_cities.sql
@@ -1,0 +1,17 @@
+create extension if not exists pgcrypto;
+
+create table if not exists cities (
+  id uuid primary key default gen_random_uuid(),
+  country_id uuid not null references countries(id) on delete cascade,
+  state_id uuid references states(id) on delete set null,
+  name text not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
+  state_lookup uuid generated always as (
+    coalesce(state_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  ) stored,
+  constraint cities_country_lookup_name_key unique (country_id, state_lookup, name)
+);
+
+create index if not exists idx_cities_country_id on cities(country_id);
+create index if not exists idx_cities_state_id on cities(state_id);

--- a/sql/008_seed_states.sql
+++ b/sql/008_seed_states.sql
@@ -1,0 +1,30 @@
+with source_states as (
+  select * from (values
+    ('US', 'California', 'CA'),
+    ('US', 'New York', 'NY'),
+    ('US', 'Texas', 'TX'),
+    ('US', 'Washington', 'WA'),
+    ('CA', 'Ontario', 'ON'),
+    ('CA', 'Quebec', 'QC'),
+    ('CA', 'British Columbia', 'BC'),
+    ('AU', 'New South Wales', 'NSW'),
+    ('AU', 'Victoria', 'VIC'),
+    ('PH', 'Metro Manila', 'NCR'),
+    ('PH', 'Cebu', 'CEB'),
+    ('GB', 'England', 'ENG'),
+    ('GB', 'Scotland', 'SCT'),
+    ('IN', 'Maharashtra', 'MH'),
+    ('IN', 'Karnataka', 'KA'),
+    ('NG', 'Lagos', 'LA'),
+    ('NG', 'Federal Capital Territory', 'FCT'),
+    ('ZA', 'Gauteng', 'GT'),
+    ('BR', 'São Paulo', 'SP'),
+    ('BR', 'Rio de Janeiro', 'RJ')
+  ) as s(country_iso_code, state_name, state_code)
+)
+insert into states (country_id, name, code)
+select c.id, s.state_name, nullif(s.state_code, '')
+from source_states s
+join countries c on upper(c.iso_code) = upper(s.country_iso_code)
+on conflict (country_id, name)
+do update set code = excluded.code, updated_at = now();

--- a/sql/009_seed_cities.sql
+++ b/sql/009_seed_cities.sql
@@ -1,0 +1,59 @@
+with source_cities as (
+  select * from (values
+    ('US', 'California', 'CA', 'Los Angeles'),
+    ('US', 'California', 'CA', 'San Francisco'),
+    ('US', 'New York', 'NY', 'New York City'),
+    ('US', 'Texas', 'TX', 'Austin'),
+    ('US', 'Washington', 'WA', 'Seattle'),
+    ('CA', 'Ontario', 'ON', 'Toronto'),
+    ('CA', 'British Columbia', 'BC', 'Vancouver'),
+    ('AU', 'New South Wales', 'NSW', 'Sydney'),
+    ('AU', 'Victoria', 'VIC', 'Melbourne'),
+    ('PH', 'Metro Manila', 'NCR', 'Quezon City'),
+    ('PH', 'Cebu', 'CEB', 'Cebu City'),
+    ('GB', 'England', 'ENG', 'London'),
+    ('GB', 'Scotland', 'SCT', 'Edinburgh'),
+    ('IN', 'Maharashtra', 'MH', 'Mumbai'),
+    ('IN', 'Karnataka', 'KA', 'Bengaluru'),
+    ('NG', 'Lagos', 'LA', 'Lagos'),
+    ('NG', 'Federal Capital Territory', 'FCT', 'Abuja'),
+    ('ZA', 'Gauteng', 'GT', 'Johannesburg'),
+    ('JP', null, null, 'Tokyo'),
+    ('JP', null, null, 'Osaka'),
+    ('SG', null, null, 'Singapore'),
+    ('AE', null, null, 'Dubai'),
+    ('AE', null, null, 'Abu Dhabi'),
+    ('FR', null, null, 'Paris'),
+    ('DE', null, null, 'Berlin'),
+    ('BR', 'São Paulo', 'SP', 'São Paulo'),
+    ('BR', 'Rio de Janeiro', 'RJ', 'Rio de Janeiro')
+  ) as c(country_iso_code, state_name, state_code, city_name)
+), resolved_cities as (
+  select
+    ctry.id as country_id,
+    ctry.iso_code,
+    trim(sc.city_name) as city_name,
+    (
+      select st.id
+      from states st
+      where st.country_id = ctry.id
+        and (
+          (sc.state_code is not null and sc.state_code <> '' and upper(st.code) = upper(sc.state_code))
+          or (
+            (sc.state_code is null or sc.state_code = '')
+            and sc.state_name is not null
+            and sc.state_name <> ''
+            and lower(st.name) = lower(sc.state_name)
+          )
+        )
+      limit 1
+    ) as state_id
+  from source_cities sc
+  join countries ctry on upper(ctry.iso_code) = upper(sc.country_iso_code)
+  where sc.city_name is not null and trim(sc.city_name) <> ''
+)
+insert into cities (country_id, state_id, name)
+select country_id, state_id, city_name
+from resolved_cities
+on conflict (country_id, state_lookup, name)
+do update set updated_at = now();

--- a/sql/data/cities.csv
+++ b/sql/data/cities.csv
@@ -1,0 +1,28 @@
+country_iso_code,country_name,state_name,state_code,city_name
+US,United States,California,CA,Los Angeles
+US,United States,California,CA,San Francisco
+US,United States,New York,NY,New York City
+US,United States,Texas,TX,Austin
+US,United States,Washington,WA,Seattle
+CA,Canada,Ontario,ON,Toronto
+CA,Canada,British Columbia,BC,Vancouver
+AU,Australia,New South Wales,NSW,Sydney
+AU,Australia,Victoria,VIC,Melbourne
+PH,Philippines,Metro Manila,NCR,Quezon City
+PH,Philippines,Cebu,CEB,Cebu City
+GB,United Kingdom,England,ENG,London
+GB,United Kingdom,Scotland,SCT,Edinburgh
+IN,India,Maharashtra,MH,Mumbai
+IN,India,Karnataka,KA,Bengaluru
+NG,Nigeria,Lagos,LA,Lagos
+NG,Nigeria,Federal Capital Territory,FCT,Abuja
+ZA,South Africa,Gauteng,GT,Johannesburg
+JP,Japan,,,Tokyo
+JP,Japan,,,Osaka
+SG,Singapore,,,Singapore
+AE,United Arab Emirates,,,Dubai
+AE,United Arab Emirates,,,Abu Dhabi
+FR,France,,,Paris
+DE,Germany,,,Berlin
+BR,Brazil,São Paulo,SP,São Paulo
+BR,Brazil,Rio de Janeiro,RJ,Rio de Janeiro

--- a/sql/data/countries.csv
+++ b/sql/data/countries.csv
@@ -1,0 +1,201 @@
+name,iso_code
+Afghanistan,AF
+Albania,AL
+Algeria,DZ
+Andorra,AD
+Angola,AO
+Antigua and Barbuda,AG
+Argentina,AR
+Armenia,AM
+Australia,AU
+Austria,AT
+Azerbaijan,AZ
+Bahamas,BS
+Bahrain,BH
+Bangladesh,BD
+Barbados,BB
+Belarus,BY
+Belgium,BE
+Belize,BZ
+Benin,BJ
+Bhutan,BT
+Bolivia,BO
+Bosnia and Herzegovina,BA
+Botswana,BW
+Brazil,BR
+Brunei Darussalam,BN
+Bulgaria,BG
+Burkina Faso,BF
+Burundi,BI
+Cabo Verde,CV
+Cambodia,KH
+Cameroon,CM
+Canada,CA
+Central African Republic,CF
+Chad,TD
+Chile,CL
+China,CN
+Colombia,CO
+Comoros,KM
+Congo,CG
+Congo (Democratic Republic of the),CD
+Costa Rica,CR
+Cote d'Ivoire,CI
+Croatia,HR
+Cuba,CU
+Cyprus,CY
+Czech Republic,CZ
+Denmark,DK
+Djibouti,DJ
+Dominica,DM
+Dominican Republic,DO
+Ecuador,EC
+Egypt,EG
+El Salvador,SV
+Equatorial Guinea,GQ
+Eritrea,ER
+Estonia,EE
+Eswatini,SZ
+Ethiopia,ET
+Fiji,FJ
+Finland,FI
+France,FR
+Gabon,GA
+Gambia,GM
+Georgia,GE
+Germany,DE
+Ghana,GH
+Greece,GR
+Grenada,GD
+Guatemala,GT
+Guinea,GN
+Guinea-Bissau,GW
+Guyana,GY
+Haiti,HT
+Honduras,HN
+Hong Kong,HK
+Hungary,HU
+Iceland,IS
+India,IN
+Indonesia,ID
+Iran,IR
+Iraq,IQ
+Ireland,IE
+Israel,IL
+Italy,IT
+Jamaica,JM
+Japan,JP
+Jordan,JO
+Kazakhstan,KZ
+Kenya,KE
+Kiribati,KI
+Korea (Democratic People's Republic of),KP
+Korea (Republic of),KR
+Kosovo,XK
+Kuwait,KW
+Kyrgyzstan,KG
+Lao People's Democratic Republic,LA
+Latvia,LV
+Lebanon,LB
+Lesotho,LS
+Liberia,LR
+Libya,LY
+Liechtenstein,LI
+Lithuania,LT
+Luxembourg,LU
+Macao,MO
+Madagascar,MG
+Malawi,MW
+Malaysia,MY
+Maldives,MV
+Mali,ML
+Malta,MT
+Marshall Islands,MH
+Mauritania,MR
+Mauritius,MU
+Mexico,MX
+Micronesia,FM
+Moldova,MD
+Monaco,MC
+Mongolia,MN
+Montenegro,ME
+Morocco,MA
+Mozambique,MZ
+Myanmar,MM
+Namibia,NA
+Nauru,NR
+Nepal,NP
+Netherlands,NL
+New Zealand,NZ
+Nicaragua,NI
+Niger,NE
+Nigeria,NG
+North Macedonia,MK
+Norway,NO
+Oman,OM
+Pakistan,PK
+Palau,PW
+Palestine,PS
+Panama,PA
+Papua New Guinea,PG
+Paraguay,PY
+Peru,PE
+Philippines,PH
+Poland,PL
+Portugal,PT
+Qatar,QA
+Romania,RO
+Russia,RU
+Rwanda,RW
+Saint Kitts and Nevis,KN
+Saint Lucia,LC
+Saint Vincent and the Grenadines,VC
+Samoa,WS
+San Marino,SM
+Sao Tome and Principe,ST
+Saudi Arabia,SA
+Senegal,SN
+Serbia,RS
+Seychelles,SC
+Sierra Leone,SL
+Singapore,SG
+Slovakia,SK
+Slovenia,SI
+Solomon Islands,SB
+Somalia,SO
+South Africa,ZA
+South Sudan,SS
+Spain,ES
+Sri Lanka,LK
+Sudan,SD
+Suriname,SR
+Sweden,SE
+Switzerland,CH
+Syria,SY
+Tajikistan,TJ
+Taiwan,TW
+Tanzania,TZ
+Thailand,TH
+Timor-Leste,TL
+Togo,TG
+Tonga,TO
+Trinidad and Tobago,TT
+Tunisia,TN
+Turkey,TR
+Turkmenistan,TM
+Tuvalu,TV
+Uganda,UG
+Ukraine,UA
+United Arab Emirates,AE
+United Kingdom,GB
+United States,US
+Uruguay,UY
+Uzbekistan,UZ
+Vanuatu,VU
+Vatican City,VA
+Venezuela,VE
+Vietnam,VN
+Western Sahara,EH
+Yemen,YE
+Zambia,ZM
+Zimbabwe,ZW

--- a/sql/data/states.csv
+++ b/sql/data/states.csv
@@ -1,0 +1,21 @@
+country_iso_code,country_name,state_name,state_code
+US,United States,California,CA
+US,United States,New York,NY
+US,United States,Texas,TX
+US,United States,Washington,WA
+CA,Canada,Ontario,ON
+CA,Canada,Quebec,QC
+CA,Canada,British Columbia,BC
+AU,Australia,New South Wales,NSW
+AU,Australia,Victoria,VIC
+PH,Philippines,Metro Manila,NCR
+PH,Philippines,Cebu,CEB
+GB,United Kingdom,England,ENG
+GB,United Kingdom,Scotland,SCT
+IN,India,Maharashtra,MH
+IN,India,Karnataka,KA
+NG,Nigeria,Lagos,LA
+NG,Nigeria,Federal Capital Territory,FCT
+ZA,South Africa,Gauteng,GT
+BR,Brazil,São Paulo,SP
+BR,Brazil,Rio de Janeiro,RJ

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,22 +1,105 @@
 const pool = require("../config/db");
 const { hashPassword, comparePassword } = require("../utils/password");
 const { signToken } = require("../utils/tokens");
-exports.register=async(req,res)=>{
- try{
-  const {name,email,password,role}=req.body;
-  if(!name||!email||!password||!role) return res.status(400).json({error:"name, email, password, role are required"});
-  const hashed=await hashPassword(password);
-  const q=await pool.query(`INSERT INTO users (name,email,password_hash,role) VALUES ($1,$2,$3,$4) RETURNING id,name,email,role,status,created_at`,[name,email,hashed,role]);
-  const user=q.rows[0]; const token=signToken({id:user.id,role:user.role,email:user.email}); res.status(201).json({user,token});
- }catch(e){ if(e.code==="23505") return res.status(409).json({error:"Email already registered"}); res.status(500).json({error:"Registration failed"}); }
+const { resolveName } = require("../utils/names");
+const { formatUserRow } = require("../utils/users");
+
+exports.register = async (req, res) => {
+  try {
+    const {
+      name,
+      firstName,
+      lastName,
+      email,
+      password,
+      role,
+      countryId,
+      phone,
+      phoneNumber,
+    } = req.body;
+    const safeName = resolveName(name, firstName, lastName);
+    const safePhone = (() => {
+      const source =
+        typeof phoneNumber === "string" && phoneNumber.trim()
+          ? phoneNumber
+          : phone;
+      return typeof source === "string" && source.trim()
+        ? source.trim()
+        : null;
+    })();
+    let safeCountryId = null;
+    if (typeof countryId === "string" && countryId.trim()) {
+      const trimmedCountryId = countryId.trim();
+      const uuidPattern =
+        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+      if (!uuidPattern.test(trimmedCountryId)) {
+        return res
+          .status(400)
+          .json({ error: "countryId must be a valid UUID" });
+      }
+      safeCountryId = trimmedCountryId;
+    }
+
+    if (!safeName || !email || !password || !role) {
+      return res
+        .status(400)
+        .json({
+          error: "A name (or firstName/lastName), email, password, and role are required",
+        });
+    }
+
+    if (safeCountryId) {
+      const countryCheck = await pool.query(
+        `SELECT id FROM countries WHERE id=$1`,
+        [safeCountryId]
+      );
+      if (!countryCheck.rows[0]) {
+        return res.status(400).json({ error: "countryId not found" });
+      }
+    }
+
+    const hashed = await hashPassword(password);
+    const q = await pool.query(
+      `INSERT INTO users (name,email,password_hash,role,phone_number,country_id)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       RETURNING id,name,email,role,status,created_at,updated_at,phone_number,country_id`,
+      [safeName, email, hashed, role, safePhone, safeCountryId]
+    );
+
+    const user = formatUserRow(q.rows[0]);
+    const token = signToken({ id: user.id, role: user.role, email: user.email });
+
+    res.status(201).json({ user, token });
+  } catch (e) {
+    if (e.code === "23505") {
+      return res.status(409).json({ error: "Email already registered" });
+    }
+    res.status(500).json({ error: "Registration failed" });
+  }
 };
-exports.login=async(req,res)=>{
- try{
-  const {email,password}=req.body; if(!email||!password) return res.status(400).json({error:"email and password required"});
-  const q=await pool.query("SELECT * FROM users WHERE email=$1",[email]); const user=q.rows[0];
-  if(!user) return res.status(401).json({error:"Invalid credentials"});
-  const ok=await comparePassword(password,user.password_hash); if(!ok) return res.status(401).json({error:"Invalid credentials"});
-  const token=signToken({id:user.id,role:user.role,email:user.email}); res.json({token});
- }catch(e){ res.status(500).json({error:"Login failed"}); }
+
+exports.login = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ error: "email and password required" });
+    }
+    const q = await pool.query("SELECT * FROM users WHERE email=$1", [email]);
+    const user = q.rows[0];
+    if (!user) {
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+    const ok = await comparePassword(password, user.password_hash);
+    if (!ok) {
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+    const token = signToken({ id: user.id, role: user.role, email: user.email });
+    res.json({ token });
+  } catch (e) {
+    res.status(500).json({ error: "Login failed" });
+  }
 };
-exports.logout=async(_req,res)=>{ res.json({message:"Logged out (client should discard token)"}); };
+
+exports.logout = async (_req, res) => {
+  res.json({ message: "Logged out (client should discard token)" });
+};

--- a/src/controllers/city.controller.js
+++ b/src/controllers/city.controller.js
@@ -1,0 +1,210 @@
+const pool = require("../config/db");
+
+const uuidPattern =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+
+const mapCity = (row) => ({
+  id: row.id,
+  name: row.name,
+  countryId: row.country_id,
+  stateId: row.state_id,
+  country: {
+    id: row.country_id,
+    name: row.country_name,
+    isoCode: row.country_iso_code,
+  },
+  state: row.state_id
+    ? {
+        id: row.state_id,
+        name: row.state_name,
+        code: row.state_code,
+      }
+    : undefined,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+exports.list = async (req, res) => {
+  try {
+    const { countryId, countryIso, stateId } = req.query;
+    const conditions = [];
+    const values = [];
+
+    if (countryId) {
+      if (!uuidPattern.test(countryId)) {
+        return res.status(400).json({ error: "countryId must be a valid UUID" });
+      }
+      values.push(countryId);
+      conditions.push(`ci.country_id = $${values.length}`);
+    }
+
+    if (countryIso) {
+      if (typeof countryIso !== "string" || countryIso.trim().length !== 2) {
+        return res
+          .status(400)
+          .json({ error: "countryIso must be a 2 character ISO code" });
+      }
+      values.push(countryIso.trim().toUpperCase());
+      conditions.push(`UPPER(c.iso_code) = $${values.length}`);
+    }
+
+    if (stateId) {
+      if (!uuidPattern.test(stateId)) {
+        return res.status(400).json({ error: "stateId must be a valid UUID" });
+      }
+      values.push(stateId);
+      conditions.push(`ci.state_id = $${values.length}`);
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const q = await pool.query(
+      `SELECT
+         ci.id,
+         ci.name,
+         ci.country_id,
+         ci.state_id,
+         ci.created_at,
+         ci.updated_at,
+         c.name AS country_name,
+         c.iso_code AS country_iso_code,
+         s.name AS state_name,
+         s.code AS state_code
+       FROM cities ci
+       JOIN countries c ON c.id = ci.country_id
+       LEFT JOIN states s ON s.id = ci.state_id
+       ${whereClause}
+       ORDER BY c.name ASC, s.name NULLS FIRST, ci.name ASC`,
+      values
+    );
+
+    res.json({ cities: q.rows.map(mapCity) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to list cities" });
+  }
+};
+
+exports.create = async (req, res) => {
+  try {
+    const { name, stateId, countryId, countryIso } = req.body;
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+
+    if (!trimmedName) {
+      return res.status(400).json({ error: "name is required" });
+    }
+
+    let resolvedStateId = null;
+    let resolvedCountryId = null;
+
+    if (stateId && typeof stateId === "string" && stateId.trim()) {
+      const normalizedStateId = stateId.trim();
+      if (!uuidPattern.test(normalizedStateId)) {
+        return res.status(400).json({ error: "stateId must be a valid UUID" });
+      }
+      const stateLookup = await pool.query(
+        `SELECT s.id, s.country_id, c.iso_code
+         FROM states s
+         JOIN countries c ON c.id = s.country_id
+         WHERE s.id = $1`,
+        [normalizedStateId]
+      );
+      if (!stateLookup.rows[0]) {
+        return res.status(400).json({ error: "stateId not found" });
+      }
+      resolvedStateId = normalizedStateId;
+      resolvedCountryId = stateLookup.rows[0].country_id;
+
+      if (countryId && typeof countryId === "string" && countryId.trim()) {
+        const normalizedCountryId = countryId.trim();
+        if (!uuidPattern.test(normalizedCountryId)) {
+          return res
+            .status(400)
+            .json({ error: "countryId must be a valid UUID" });
+        }
+        if (normalizedCountryId !== resolvedCountryId) {
+          return res
+            .status(400)
+            .json({ error: "countryId does not match stateId" });
+        }
+      }
+
+      if (countryIso && typeof countryIso === "string") {
+        const normalizedIso = countryIso.trim().toUpperCase();
+        if (normalizedIso.length !== 2) {
+          return res
+            .status(400)
+            .json({ error: "countryIso must be a 2 character ISO code" });
+        }
+        if (normalizedIso !== stateLookup.rows[0].iso_code) {
+          return res
+            .status(400)
+            .json({ error: "countryIso does not match stateId" });
+        }
+      }
+    } else {
+      let normalizedCountryId = null;
+      if (countryId && typeof countryId === "string" && countryId.trim()) {
+        normalizedCountryId = countryId.trim();
+        if (!uuidPattern.test(normalizedCountryId)) {
+          return res
+            .status(400)
+            .json({ error: "countryId must be a valid UUID" });
+        }
+      }
+
+      if (!normalizedCountryId && countryIso && typeof countryIso === "string") {
+        const normalizedIso = countryIso.trim().toUpperCase();
+        if (normalizedIso.length !== 2) {
+          return res
+            .status(400)
+            .json({ error: "countryIso must be a 2 character ISO code" });
+        }
+        const countryLookup = await pool.query(
+          "SELECT id FROM countries WHERE iso_code = $1",
+          [normalizedIso]
+        );
+        if (!countryLookup.rows[0]) {
+          return res.status(400).json({ error: "countryIso not found" });
+        }
+        normalizedCountryId = countryLookup.rows[0].id;
+      }
+
+      if (!normalizedCountryId) {
+        return res
+          .status(400)
+          .json({ error: "stateId or countryId/countryIso is required" });
+      }
+
+      resolvedCountryId = normalizedCountryId;
+    }
+
+    const q = await pool.query(
+      `WITH inserted AS (
+         INSERT INTO cities (name, country_id, state_id)
+         VALUES ($1, $2, $3)
+         RETURNING id, name, country_id, state_id, created_at, updated_at
+       )
+       SELECT i.id,
+              i.name,
+              i.country_id,
+              i.state_id,
+              i.created_at,
+              i.updated_at,
+              c.name AS country_name,
+              c.iso_code AS country_iso_code,
+              s.name AS state_name,
+              s.code AS state_code
+       FROM inserted i
+       JOIN countries c ON c.id = i.country_id
+       LEFT JOIN states s ON s.id = i.state_id`,
+      [trimmedName, resolvedCountryId, resolvedStateId]
+    );
+
+    res.status(201).json({ city: mapCity(q.rows[0]) });
+  } catch (e) {
+    if (e.code === "23505") {
+      return res.status(409).json({ error: "City already exists for location" });
+    }
+    res.status(500).json({ error: "Failed to create city" });
+  }
+};

--- a/src/controllers/country.controller.js
+++ b/src/controllers/country.controller.js
@@ -1,0 +1,52 @@
+const pool = require("../config/db");
+
+const mapCountry = (row) => ({
+  id: row.id,
+  name: row.name,
+  isoCode: row.iso_code,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+exports.list = async (_req, res) => {
+  try {
+    const q = await pool.query(
+      `SELECT id, name, iso_code, created_at, updated_at FROM countries ORDER BY name ASC`
+    );
+    res.json({ countries: q.rows.map(mapCountry) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to list countries" });
+  }
+};
+
+exports.create = async (req, res) => {
+  try {
+    const { name, isoCode } = req.body;
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+    const normalizedIso =
+      typeof isoCode === "string" && isoCode.trim()
+        ? isoCode.trim().toUpperCase()
+        : null;
+
+    if (!trimmedName) {
+      return res.status(400).json({ error: "name is required" });
+    }
+
+    if (normalizedIso && normalizedIso.length !== 2) {
+      return res.status(400).json({ error: "isoCode must be 2 characters" });
+    }
+
+    const q = await pool.query(
+      `INSERT INTO countries (name, iso_code) VALUES ($1, $2)
+       RETURNING id, name, iso_code, created_at, updated_at`,
+      [trimmedName, normalizedIso]
+    );
+
+    res.status(201).json({ country: mapCountry(q.rows[0]) });
+  } catch (e) {
+    if (e.code === "23505") {
+      return res.status(409).json({ error: "Country already exists" });
+    }
+    res.status(500).json({ error: "Failed to create country" });
+  }
+};

--- a/src/controllers/state.controller.js
+++ b/src/controllers/state.controller.js
@@ -1,0 +1,139 @@
+const pool = require("../config/db");
+
+const uuidPattern =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+
+const mapState = (row) => ({
+  id: row.id,
+  name: row.name,
+  code: row.code,
+  countryId: row.country_id,
+  country: row.country_name
+    ? {
+        id: row.country_id,
+        name: row.country_name,
+        isoCode: row.country_iso_code,
+      }
+    : undefined,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+exports.list = async (req, res) => {
+  try {
+    const { countryId, countryIso } = req.query;
+    const conditions = [];
+    const values = [];
+
+    if (countryId) {
+      if (!uuidPattern.test(countryId)) {
+        return res.status(400).json({ error: "countryId must be a valid UUID" });
+      }
+      values.push(countryId);
+      conditions.push(`s.country_id = $${values.length}`);
+    }
+
+    if (countryIso) {
+      if (typeof countryIso !== "string" || countryIso.trim().length !== 2) {
+        return res
+          .status(400)
+          .json({ error: "countryIso must be a 2 character ISO code" });
+      }
+      values.push(countryIso.trim().toUpperCase());
+      conditions.push(`UPPER(c.iso_code) = $${values.length}`);
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const q = await pool.query(
+      `SELECT
+         s.id,
+         s.name,
+         s.code,
+         s.country_id,
+         s.created_at,
+         s.updated_at,
+         c.name AS country_name,
+         c.iso_code AS country_iso_code
+       FROM states s
+       JOIN countries c ON c.id = s.country_id
+       ${whereClause}
+       ORDER BY c.name ASC, s.name ASC`,
+      values
+    );
+
+    res.json({ states: q.rows.map(mapState) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to list states" });
+  }
+};
+
+exports.create = async (req, res) => {
+  try {
+    const { name, code, countryId, countryIso } = req.body;
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+    const trimmedCode = typeof code === "string" ? code.trim().toUpperCase() : "";
+
+    if (!trimmedName) {
+      return res.status(400).json({ error: "name is required" });
+    }
+
+    let resolvedCountryId = null;
+    if (countryId && typeof countryId === "string" && countryId.trim()) {
+      const normalized = countryId.trim();
+      if (!uuidPattern.test(normalized)) {
+        return res.status(400).json({ error: "countryId must be a valid UUID" });
+      }
+      resolvedCountryId = normalized;
+    } else if (countryIso && typeof countryIso === "string") {
+      const normalizedIso = countryIso.trim().toUpperCase();
+      if (normalizedIso.length !== 2) {
+        return res
+          .status(400)
+          .json({ error: "countryIso must be a 2 character ISO code" });
+      }
+      const countryLookup = await pool.query(
+        "SELECT id FROM countries WHERE iso_code = $1",
+        [normalizedIso]
+      );
+      if (!countryLookup.rows[0]) {
+        return res.status(400).json({ error: "countryIso not found" });
+      }
+      resolvedCountryId = countryLookup.rows[0].id;
+    } else {
+      return res.status(400).json({ error: "countryId or countryIso is required" });
+    }
+
+    if (trimmedCode && trimmedCode.length > 10) {
+      return res
+        .status(400)
+        .json({ error: "code must be 10 characters or fewer" });
+    }
+
+    const q = await pool.query(
+      `WITH inserted AS (
+         INSERT INTO states (name, code, country_id)
+         VALUES ($1, NULLIF($2, ''), $3)
+         RETURNING id, name, code, country_id, created_at, updated_at
+       )
+       SELECT i.id,
+              i.name,
+              i.code,
+              i.country_id,
+              i.created_at,
+              i.updated_at,
+              c.name AS country_name,
+              c.iso_code AS country_iso_code
+       FROM inserted i
+       JOIN countries c ON c.id = i.country_id`,
+      [trimmedName, trimmedCode, resolvedCountryId]
+    );
+
+    res.status(201).json({ state: mapState(q.rows[0]) });
+  } catch (e) {
+    if (e.code === "23505") {
+      return res.status(409).json({ error: "State already exists for country" });
+    }
+    res.status(500).json({ error: "Failed to create state" });
+  }
+};

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,4 +1,49 @@
 const pool = require("../config/db");
-exports.me=async(req,res)=>{ try{ const q=await pool.query(`SELECT id,name,email,role,status,created_at,updated_at FROM users WHERE id=$1`,[req.user.id]); res.json({user:q.rows[0]}); }catch(e){ res.status(500).json({error:"Failed to fetch profile"});} };
-exports.list=async(_req,res)=>{ try{ const q=await pool.query(`SELECT id,name,email,role,status,created_at FROM users ORDER BY created_at DESC`); res.json({users:q.rows}); }catch(e){ res.status(500).json({error:"Failed to list users"});} };
-exports.getById=async(req,res)=>{ try{ const q=await pool.query(`SELECT id,name,email,role,status,created_at FROM users WHERE id=$1`,[req.params.id]); if(!q.rows[0]) return res.status(404).json({error:"Not found"}); res.json({user:q.rows[0]}); }catch(e){ res.status(500).json({error:"Failed to get user"});} };
+const { formatUserRow } = require("../utils/users");
+
+const baseUserQuery = `
+  SELECT
+    u.id,
+    u.name,
+    u.email,
+    u.role,
+    u.status,
+    u.created_at,
+    u.updated_at,
+    u.phone_number,
+    u.country_id,
+    c.name AS country_name,
+    c.iso_code AS country_iso_code
+  FROM users u
+  LEFT JOIN countries c ON c.id = u.country_id
+`;
+
+exports.me = async (req, res) => {
+  try {
+    const q = await pool.query(`${baseUserQuery} WHERE u.id = $1`, [req.user.id]);
+    res.json({ user: formatUserRow(q.rows[0]) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to fetch profile" });
+  }
+};
+
+exports.list = async (_req, res) => {
+  try {
+    const q = await pool.query(`${baseUserQuery} ORDER BY u.created_at DESC`);
+    res.json({ users: q.rows.map(formatUserRow) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to list users" });
+  }
+};
+
+exports.getById = async (req, res) => {
+  try {
+    const q = await pool.query(`${baseUserQuery} WHERE u.id = $1`, [req.params.id]);
+    if (!q.rows[0]) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    res.json({ user: formatUserRow(q.rows[0]) });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to get user" });
+  }
+};

--- a/src/routes/city.routes.js
+++ b/src/routes/city.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const cities = require("../controllers/city.controller");
+const { requireAuth, requireRole } = require("../middleware/auth");
+
+router.get("/", cities.list);
+router.post("/", requireAuth, requireRole("admin"), cities.create);
+
+module.exports = router;

--- a/src/routes/country.routes.js
+++ b/src/routes/country.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const countries = require("../controllers/country.controller");
+const { requireAuth, requireRole } = require("../middleware/auth");
+
+router.get("/", countries.list);
+router.post("/", requireAuth, requireRole("admin"), countries.create);
+
+module.exports = router;

--- a/src/routes/state.routes.js
+++ b/src/routes/state.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const states = require("../controllers/state.controller");
+const { requireAuth, requireRole } = require("../middleware/auth");
+
+router.get("/", states.list);
+router.post("/", requireAuth, requireRole("admin"), states.create);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -23,6 +23,9 @@ app.use("/users", require("./routes/user.routes"));
 app.use("/services", require("./routes/service.routes"));
 app.use("/items", require("./routes/item.routes"));
 app.use("/bookings", require("./routes/booking.routes"));
+app.use("/countries", require("./routes/country.routes"));
+app.use("/states", require("./routes/state.routes"));
+app.use("/cities", require("./routes/city.routes"));
 
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/utils/names.js
+++ b/src/utils/names.js
@@ -1,0 +1,33 @@
+const normalize = (value) =>
+  typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+
+const resolveName = (name, firstName, lastName) => {
+  const legacy = normalize(name);
+  if (legacy) {
+    return legacy;
+  }
+
+  const safeFirst = normalize(firstName);
+  const safeLast = normalize(lastName);
+
+  const combined = [safeFirst, safeLast].filter(Boolean).join(" ");
+  return combined.trim();
+};
+
+const splitName = (fullName) => {
+  const normalized = normalize(fullName);
+  if (!normalized) {
+    return { firstName: "", lastName: "" };
+  }
+
+  const [first, ...rest] = normalized.split(" ");
+  return {
+    firstName: first || "",
+    lastName: rest.join(" ") || "",
+  };
+};
+
+module.exports = {
+  resolveName,
+  splitName,
+};

--- a/src/utils/users.js
+++ b/src/utils/users.js
@@ -1,0 +1,53 @@
+const { splitName } = require("./names");
+
+const has = (row, key) => Object.prototype.hasOwnProperty.call(row, key);
+
+const buildCountry = (row) => {
+  if (!has(row, "country_id") && !has(row, "country_name") && !has(row, "country_iso_code")) {
+    return undefined;
+  }
+
+  const present = row.country_id || row.country_name || row.country_iso_code;
+  if (!present) {
+    return null;
+  }
+
+  return {
+    id: row.country_id || null,
+    name: row.country_name || null,
+    isoCode: row.country_iso_code || null,
+  };
+};
+
+const formatUserRow = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  const { firstName, lastName } = splitName(row.name);
+
+  const formatted = {
+    id: row.id,
+    name: row.name,
+    firstName,
+    lastName,
+    email: row.email,
+    role: row.role,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    phoneNumber: has(row, "phone_number") ? row.phone_number : undefined,
+    countryId: has(row, "country_id") ? row.country_id : undefined,
+  };
+
+  const country = buildCountry(row);
+  if (country !== undefined) {
+    formatted.country = country;
+  }
+
+  return formatted;
+};
+
+module.exports = {
+  formatUserRow,
+};


### PR DESCRIPTION
## Summary
- add SQL helper scripts that seed the states and cities tables using ISO country codes
- resolve state UUIDs when available so inserts reuse existing rows and remain idempotent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54761c1488324a8d5d3bbc0c63311